### PR TITLE
add force_context for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Automatic testing is provided using molecule's delegated driver and <https://bui
 
 This role requires root access and should be run with `become=yes`.
 
+## Dependencies
+
+collection community.mysql >= 3.1.0 (included in ansible >= 6.x)
+
 ## Role Variables
 
 | Variable | Description | Default |

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,5 +9,6 @@
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
     login_unix_socket: "{{ mysql_socket }}"
+    force_context: true
   loop: "{{ mysql_users }}"
   no_log: true


### PR DESCRIPTION
without force_context option binlog filters doesn't work.